### PR TITLE
Correção dos Tipos no Schema

### DIFF
--- a/src/stories/Schema.stories.tsx
+++ b/src/stories/Schema.stories.tsx
@@ -16,7 +16,7 @@ type Story = StoryObj<SchemaProps>
  
 const schema: SchemaType[] = [
     {
-        formtool: 'select',
+        formtool: 'text',
         label: 'Teste',
         name: 'teste',
     }

--- a/src/stories/Schema.stories.tsx
+++ b/src/stories/Schema.stories.tsx
@@ -16,9 +16,9 @@ type Story = StoryObj<SchemaProps>
  
 const schema: SchemaType[] = [
     {
-        formtool: 'text',
+        formtool: 'select',
         label: 'Teste',
-        name: 'test'
+        name: 'teste',
     }
 ]
 

--- a/src/types/inputs.ts
+++ b/src/types/inputs.ts
@@ -38,11 +38,11 @@ export type OptionType = {
 	value: any
 }
 
-export type SelectProps = Omit<DefaultProps, 'aftericon'> & OmitedProps<HTMLSelectElement> & {
+export type SelectProps = Omit<DefaultProps, 'aftericon'> & OmitedProps<HTMLSelectElement> & ({
 	options: OptionType[]
-} & {
-	asyncLoad?: () => Promise<any>
-}
+} | {
+	asyncLoad: () => Promise<any>
+})
 
 
 export interface SearchProps extends Omit<DefaultProps, 'aftericon'>, OmitedProps<HTMLSelectElement> {
@@ -75,11 +75,15 @@ export interface FileProps extends DefaultProps, OmitedProps<HTMLInputElement> {
 }
 
 
-export interface TaglistProps extends Omit<DefaultProps, 'aftericon'>, OmitedProps<HTMLInputElement> {
-	options?: OptionType[],
-	asyncLoad?: () => Promise<any>,
-	type?: 'typing' | 'async' | 'options',
-}
+export type TaglistProps = Omit<DefaultProps, 'aftericon'> & OmitedProps<HTMLInputElement> & ({
+	type: 'options'
+	options: OptionType[]
+} | {
+    type: 'async'
+	asyncLoad: () => Promise<any>
+} | {
+    type: 'typing'
+})
 
 
 export interface MaskProps extends ReactMaskProps<HTMLInputElement>, DefaultProps {

--- a/src/types/inputs.ts
+++ b/src/types/inputs.ts
@@ -38,8 +38,9 @@ export type OptionType = {
 	value: any
 }
 
-export interface SelectProps extends Omit<DefaultProps, 'aftericon'>, OmitedProps<HTMLSelectElement> {
-	options?: OptionType[],
+export type SelectProps = Omit<DefaultProps, 'aftericon'> & OmitedProps<HTMLSelectElement> & {
+	options: OptionType[]
+} & {
 	asyncLoad?: () => Promise<any>
 }
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -11,6 +11,7 @@ import {
     PasswordProps
 } from '../types/inputs'
 
+/* TIPOS DO INPUT */
 export type InputTypes = 'email'|
 "text"|
 "number"|
@@ -25,6 +26,11 @@ export type InputTypes = 'email'|
 "tel"|
 'password' 
 
+export interface InputSchemaProps extends InputProps {
+    formtool: InputTypes
+}
+
+/* TIPOS DOS OUTROS ELEMENTOS */
 export type ElementsTypes = "checkbox" |
 'select' |
 'search' |
@@ -35,9 +41,18 @@ export type ElementsTypes = "checkbox" |
 'taglist' |
 'group'
 
-export type SchemaType  = (InputProps | PasswordProps | CheckboxProps | SelectProps | SearchProps | FileProps | RadioProps | TaglistProps | ToggleProps | MaskProps | GroupProps | { [x: string]: any }) & {
-    formtool: InputTypes | ElementsTypes | string
+// Checkbox
+export interface CheckboxSchemaProps extends CheckboxProps {
+    formtool: 'checkbox'
 }
+
+// Select
+export interface SelectSchemaProps extends SelectProps {
+    formtool: 'select'
+}
+
+/* TIPOS DO SCHEMA */
+export type SchemaType  = InputSchemaProps | CheckboxSchemaProps | SelectSchemaProps
 
 export type GroupProps = {
     title?: string,

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -47,17 +47,59 @@ export interface CheckboxSchemaProps extends CheckboxProps {
 }
 
 // Select
-export interface SelectSchemaProps extends SelectProps {
+export type SelectSchemaProps = SelectProps & {
     formtool: 'select'
 }
 
-/* TIPOS DO SCHEMA */
-export type SchemaType  = InputSchemaProps | CheckboxSchemaProps | SelectSchemaProps
+// Search
+export interface SearchSchemaProps extends SearchProps {
+    formtool: 'search'
+}
 
-export type GroupProps = {
+// File
+export interface FileSchemaProps extends FileProps {
+    formtool: 'file'
+}
+
+// Mask
+export interface MaskSchemaProps extends MaskProps {
+    formtool: 'mask'
+}
+
+// Radio
+export interface RadioSchemaProps extends RadioProps {
+    formtool: 'radio'
+}
+
+// Toggle
+export interface ToggleSchemaProps extends ToggleProps {
+    formtool: 'toggle'
+}
+
+// Taglist
+export type TaglistSchemaProps = TaglistProps & {
+    formtool: 'taglist'
+}
+
+// Group
+export type GroupSchemaProps = {
+    formtool: 'group'
     title?: string,
     schema: SchemaType[]
 }
+
+
+/* TIPOS DO SCHEMA */
+export type SchemaType  = InputSchemaProps |
+    CheckboxSchemaProps |
+    SelectSchemaProps |
+    SearchSchemaProps |
+    FileSchemaProps |
+    MaskSchemaProps |
+    RadioSchemaProps |
+    ToggleSchemaProps |
+    TaglistSchemaProps |
+    GroupSchemaProps
 
 export interface SchemaProps {
 	schema: SchemaType[]


### PR DESCRIPTION
Correção dos tipos no schema, agora quando você digita o 'formtool', as propriedades do formtool passado são as que vão aparecer e ser requeridas